### PR TITLE
fixes for pr 19

### DIFF
--- a/ontquery/plugins/interlex_client.py
+++ b/ontquery/plugins/interlex_client.py
@@ -69,6 +69,11 @@ class InterLexClient:
         self.base_url = base_url
         self.api_key = os.environ.get(
             'INTERLEX_API_KEY', os.environ.get('SCICRUNCH_API_KEY', None))
+
+        if self.api_key is None:
+            # we don't error here because API keys are not required for viewing
+            log.warning('You have not set an API key for the SciCrunch API!')
+
         self._kwargs = {}
         if 'test' in base_url:
             auth = os.environ.get('SCICRUNCH_TEST_U'), os.environ.get(
@@ -81,9 +86,6 @@ class InterLexClient:
                     'export SCICRUNCH_TEST_U=put_user_here\n'
                     'export SCICRUNCH_TEST_P=put_password_here'
                 )
-            self.api_key = os.environ.get(
-                'INTERLEX_API_KEY_TEST', os.environ.get(
-                    'SCICRUNCH_API_KEY_TEST', None))
             if not self.api_key:
                 raise self.IncorrectAPIKeyError(
                     'TEST api_key not found. Please go to '

--- a/test/test_interlex_client.py
+++ b/test/test_interlex_client.py
@@ -21,15 +21,14 @@ def test_api_key():
     ilxremote = InterLexRemote(apiEndpoint=API_BASE)
     ilxremote.setup(instrumented=oq.OntTerm)
     ilx_cli = ilxremote.ilx_cli
-    assert ilx_cli.api_key == ilxremote.api_key
-    os.environ['INTERLEX_API_KEY_TEST'] = 'fake_key_12345'  # shadows the scicrunch key in tests
+    os.environ['INTERLEX_API_KEY'] = 'fake_key_12345'  # shadows the scicrunch key in tests
     with pytest.raises(ilx_cli.IncorrectAPIKeyError,
                        match = "api_key given is incorrect."):
         ilxremote = InterLexRemote(apiEndpoint=API_BASE)
         ilxremote.setup(instrumented=oq.OntTerm)
 
-    os.environ.pop('INTERLEX_API_KEY_TEST')  # unshadow
-    assert not os.environ.get('INTERLEX_API_KEY_TEST')
+    os.environ.pop('INTERLEX_API_KEY')  # unshadow
+    assert not os.environ.get('INTERLEX_API_KEY')
 
 
 ilxremote = InterLexRemote(apiEndpoint=API_BASE)


### PR DESCRIPTION
don't set a different api key for test
don't set an api key at all for InterLexRemote, this may change a bit
when we work out orthauth

use yield from for scicrunch api query and yield for dev query